### PR TITLE
feat: Display Pomodoro timer countdown in closed notch

### DIFF
--- a/add_file.py
+++ b/add_file.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import re
+
+with open('boringNotch.xcodeproj/project.pbxproj', 'r') as f:
+    content = f.read()
+
+# Add PBXBuildFile entry after PomodoroView.swift in Sources
+build_pattern = r'(POMOD0042C5EAFBF00000004 /\* PomodoroView\.swift in Sources \* / = \{isa = PBXBuildFile; fileRef = POMOD0022C5EAFBF00000002 /\* PomodoroView\.swift \* /; \};)'
+build_replacement = r'\1\n\t\tPOMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */; };'
+content = re.sub(build_pattern, build_replacement, content)
+
+# Add PBXFileReference entry after PomodoroView.swift file reference
+file_pattern = r'(POMOD0022C5EAFBF00000002 /\* PomodoroView\.swift \* / = \{isa = PBXFileReference; lastKnownFileType = sourcecode\.swift; path = PomodoroView\.swift; sourceTree = "<group>"; \};)'
+file_replacement = r'\1\n\t\tPOMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroClosedView.swift; sourceTree = "<group>"; };'
+content = re.sub(file_pattern, file_replacement, content)
+
+# Add to PBXSourcesBuildPhase
+sources_pattern = r'(POMOD0042C5EAFBF00000004 /\* PomodoroView\.swift in Sources \* /,)'
+sources_replacement = r'\1\n\t\t\t\tPOMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */,'
+content = re.sub(sources_pattern, sources_replacement, content)
+
+with open('boringNotch.xcodeproj/project.pbxproj', 'w') as f:
+    f.write(content)
+
+print("Done")

--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */; };
 		POMOD0032C5EAFBF00000003 /* PomodoroManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */; };
 		POMOD0042C5EAFBF00000004 /* PomodoroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMOD0022C5EAFBF00000002 /* PomodoroView.swift */; };
+		POMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -313,6 +314,7 @@
 		F38DE6472D8243E2008B5C6D /* BatteryActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryActivityManager.swift; sourceTree = "<group>"; };
 		POMOD0012C5EAFBF00000001 /* PomodoroManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroManager.swift; sourceTree = "<group>"; };
 		POMOD0022C5EAFBF00000002 /* PomodoroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroView.swift; sourceTree = "<group>"; };
+		POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomodoroClosedView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -507,6 +509,7 @@
 				B10F84A22C6C9596009F3026 /* TestView.swift */,
 				507266DA2C908E2E00A2D00D /* HoverButton.swift */,
 				POMOD0022C5EAFBF00000002 /* PomodoroView.swift */,
+				POMODCLOS0002C5EAFBF00000001 /* PomodoroClosedView.swift */,
 				B1F747F82EC7E94000F841DB /* LottieView.swift */,
 			);
 			path = components;
@@ -1003,6 +1006,7 @@
 				F38DE6482D8243E7008B5C6D /* BatteryActivityManager.swift in Sources */,
 				POMOD0032C5EAFBF00000003 /* PomodoroManager.swift in Sources */,
 				POMOD0042C5EAFBF00000004 /* PomodoroView.swift in Sources */,
+				POMODCLOS0001C5EAFBF00000001 /* PomodoroClosedView.swift in Sources */,
 				B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */,
 				118D1FD12E98FF5F00A2FF63 /* SharingStateManager.swift in Sources */,
 				14D570C22C5EAFBF0011E668 /* EmptyState.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -17,9 +17,10 @@ import SwiftUIIntrospect
 struct ContentView: View {
     @EnvironmentObject var vm: BoringViewModel
     @ObservedObject var webcamManager = WebcamManager.shared
-
+    
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     @ObservedObject var musicManager = MusicManager.shared
+    @ObservedObject var pomodoroManager = PomodoroManager.shared
     @ObservedObject var batteryModel = BatteryStatusViewModel.shared
     @ObservedObject var brightnessManager = BrightnessManager.shared
     @ObservedObject var volumeManager = VolumeManager.shared
@@ -292,8 +293,13 @@ struct ContentView: View {
                               
                               Spacer()
                               
-                              // Face on right
-                              if Defaults[.showNotHumanFace] {
+                              // Pomodoro timer on right (if running)
+                              if pomodoroManager.isRunning {
+                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
+                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
+                              }
+                              // Face on right (if enabled and timer not running)
+                              else if Defaults[.showNotHumanFace] {
                                   AnimatedFaceView()
                                       .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
                                              height: max(0, vm.effectiveClosedNotchHeight - 16))

--- a/boringNotch/components/PomodoroClosedView.swift
+++ b/boringNotch/components/PomodoroClosedView.swift
@@ -1,0 +1,51 @@
+//
+//  PomodoroClosedView.swift
+//  boringNotch
+//
+//  Created by Claw on 2026-04-29.
+//  Compact timer display for closed notch state.
+//
+
+import SwiftUI
+
+struct PomodoroClosedView: View {
+    @ObservedObject var pomodoroManager: PomodoroManager
+    
+    var body: some View {
+        HStack(spacing: 6) {
+            // Phase indicator dot
+            Circle()
+                .fill(phaseColor)
+                .frame(width: 6, height: 6)
+            
+            // Timer text
+            Text(pomodoroManager.formattedTime)
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundColor(.white)
+            
+            // Sessions counter
+            if pomodoroManager.sessionsCompleted > 0 {
+                Text("•\(pomodoroManager.sessionsCompleted)")
+                    .font(.system(size: 10))
+                    .foregroundColor(.gray)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.black.opacity(0.5))
+        )
+    }
+    
+    private var phaseColor: Color {
+        switch pomodoroManager.currentPhase {
+        case .work:
+            return Color(red: 1.0, green: 0.4, blue: 0.4) // Red for work
+        case .shortBreak:
+            return Color(red: 0.4, green: 1.0, blue: 0.4) // Green for short break
+        case .longBreak:
+            return Color(red: 0.4, green: 0.8, blue: 1.0) // Blue for long break
+        }
+    }
+}


### PR DESCRIPTION
## Description

Displays Pomodoro timer countdown in the closed notch when the timer is running.

### Features
- Phase indicator dot (colored: red for work, green for short break, blue for long break)
- Timer text in MM:SS format (monospaced font)
- Sessions counter shown when sessions > 0
- Compact pill-shaped background

### Logic
- Shows timer when `pomodoroManager.isRunning`
- Hides timer when paused/stopped
- Face animation shown when timer not running
- Music icon on left, timer/face on right

Closes #6