### PR TITLE
fix: Order timer before face in closed notch

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -293,17 +293,17 @@ struct ContentView: View {
                               
                               Spacer()
                               
+                              // Pomodoro timer on left of face (if running)
+                              if pomodoroManager.isRunning {
+                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
+                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
+                              }
+                              
                               // Face on right side
                               if Defaults[.showNotHumanFace] {
                                   AnimatedFaceView()
                                       .frame(width: max(0, vm.effectiveClosedNotchHeight - 16),
                                              height: max(0, vm.effectiveClosedNotchHeight - 16))
-                              }
-                              
-                              // Pomodoro timer next to face on right (if running)
-                              if pomodoroManager.isRunning {
-                                  PomodoroClosedView(pomodoroManager: pomodoroManager)
-                                      .frame(height: max(0, vm.effectiveClosedNotchHeight - 12))
                               }
                           }
                           .padding(.horizontal, 8)


### PR DESCRIPTION
Fixes order so timer appears before face:

`[music]    Spacer    [🔴 25:00]    [face]`